### PR TITLE
Inject env tokens if Runner provides Container spec

### DIFF
--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -382,6 +382,9 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 
 	if len(runner.Spec.Containers) != 0 {
 		pod.Spec.Containers = runner.Spec.Containers
+		for i := 0; i < len(pod.Spec.Containers); i++ {
+			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, env)
+		}
 	}
 
 	if len(runner.Spec.VolumeMounts) != 0 {


### PR DESCRIPTION
The API allows for the Runner to completely override the Container definition.  However, if this capability is used, the container no longer has access to the env vars required for the runner to connect to Github.  Inject these vars into the overridden container spec too